### PR TITLE
fix: indentation of <ul>

### DIFF
--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -533,7 +533,8 @@ p {
 
 ul, ol {
   margin-top: 1.7rem;
-  margin-bottom: 1.7rem; }
+  margin-bottom: 1.7rem;
+  margin-left: 1rem; }
   ul ul, ul ol, ol ul, ol ol {
     margin-top: 0;
     margin-bottom: 0; }


### PR DESCRIPTION
This add a small indentation to `<ul/>` and `<ol/>` lists, to avoid the bullets to be on the border of the `modal-content`.